### PR TITLE
Remove dependency to uhd/utils/atomic.hpp

### DIFF
--- a/apps/record/specrec.cpp
+++ b/apps/record/specrec.cpp
@@ -33,7 +33,7 @@
 #include <complex>
 #include <ctime>
 #include <boost/atomic.hpp>
-#include <uhd/utils/atomic.hpp>
+//#include <uhd/utils/atomic.hpp>
 // need PMT for metadata headers
 #include <pmt/pmt.h>
 //pthread lib


### PR DESCRIPTION
Hi,

I had the following error when trying to build gr-analysis:

```
Scanning dependencies of target specrec
[ 93%] Building CXX object apps/record/CMakeFiles/specrec.dir/specrec.cpp.o
In file included from /home/israiri/sdr/workarea-gnuradio/gr-analysis/apps/record/specrec.cpp:36:0:
/usr/include/uhd/utils/atomic.hpp: In function ‘bool uhd::spin_wait_with_timeout(uhd::atomic_uint32_t&, uint32_t, double)’:
/usr/include/uhd/utils/atomic.hpp:153:52: error: ‘get_system_time’ is not a member of ‘uhd::time_spec_t’
         const time_spec_t exit_time = time_spec_t::get_system_time() + time_spec_t(timeout);
                                                    ^~~~~~~~~~~~~~~
/usr/include/uhd/utils/atomic.hpp:155:30: error: ‘get_system_time’ is not a member of ‘uhd::time_spec_t’
             if (time_spec_t::get_system_time() > exit_time) return false;
                              ^~~~~~~~~~~~~~~
apps/record/CMakeFiles/specrec.dir/build.make:62: recipe for target 'apps/record/CMakeFiles/specrec.dir/specrec.cpp.o' failed
make[2]: *** [apps/record/CMakeFiles/specrec.dir/specrec.cpp.o] Error 1

```

so I ended up removing the dependency to uhd/utils/atomic.hpp.

Commit message:

This dependency seems no longer necessary since the following line
//uhd::time_spec_t timestamp = uhd::time_spec_t::get_system_time();
was commented in commit db6454fb35530b9ce46aa0cf6b6dce101af3fecd.


Thanks.